### PR TITLE
Reword explanation of model binding in a context

### DIFF
--- a/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
+++ b/Chapter2_MorePyMC/Ch2_MorePyMC_PyMC3.ipynb
@@ -103,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each variable assigned to a model will be defined with its own name, the first string parameter (we will cover this further in the variables section). To reset the model, we need only run the first block of code again."
+    "Each variable assigned to a model will be defined with its own name, the first string parameter (we will cover this further in the variables section). To create a new model, we need only run the first block of code again."
    ]
   },
   {
@@ -131,7 +131,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also simply define an entirely new model. Note that we are free to name our models whatever we like, so if we do not want to overwrite an old model we need only make another."
+    "We can also define an entirely separate model. Note that we are free to name our models whatever we like, so if we do not want to overwrite an old model we need only make another."
    ]
   },
   {


### PR DESCRIPTION
In Chapter 2, the markdown prior to `In [4]` says, "[t]o reset the model [...]".  I initially read this as though there was some sort of weird introspection going on where the `pymc3.model.Model` object bound to `model` dropped its variables; then, it added the new ones. I didn't read the underlying code, but that seems unlikely -- it's just seems like a new binding. (The object IDs of `model` before and after supports this.) Unless I am incorrect, this bit of text may confuse people. 

P.S. Thanks for doing this! Since I read @CamDavidsonPilon's book already, this is a great map to learn PyMC3.
